### PR TITLE
#37 satonoさんのindex.html改訳案を取り込み

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ overview: true
 <section class="intro">
   <div class="grid">
     <div class="unit whole center-on-mobiles">
-      <p class="first">プレーンテキストを静的な Web サイトやブログに変換します。</p>
+      <p class="first">プレーンテキストから静的な Web サイトやブログを作成しましょう。</p>
       <!--
       <p class="first">Transform your plain text into static&nbsp;websites and&nbsp;blogs.</p>
       -->
@@ -27,7 +27,7 @@ overview: true
       <h2>Simple</h2>
       -->
       <p>
-        データベースや、コメント管理や、インストールのためのやっかいなアップデートは不要です。 — <em>あなたのコンテンツ</em>に集中できます。
+        データベース、コメント管理、やっかいなアップデートのインストールは不要です。 — <em>あなたのコンテンツ</em>に集中できます。
       </p>
       <!--
       <p>


### PR DESCRIPTION
「起動から実行まで」はあえて残し。

右に表示される Quick-start Instructions の手順を見ていると
個人的にはどうしてもそういうニュアンスの方がいいかなぁと思うので、原文の `Get up and running` そのままで。
