### PR TITLE
docs/extras.mdの翻訳部分のendhighlightタグが正しく閉じられていなかったのを修正

### DIFF
--- a/docs/extras.md
+++ b/docs/extras.md
@@ -171,6 +171,7 @@ class Jekyll::Converters::Markdown::MyCustomParser
     SomeRenderer.new(@site_config).to_html(content)
   end
 end
+{% endhighlight %}
 
 <!--original
 {% highlight ruby %}


### PR DESCRIPTION
確認漏れでした。
簡単に確認する方法を確立しないとなー
