### PR TITLE
.gitignore追加。bundler使用〜jekyll buildするところまでの不要ファイルを記載

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.bundle
+_site
+Gemfile.lock
+vendor


### PR DESCRIPTION
そういえば、.gitignoreはあった方がいいかも。
