### PR TITLE
ローカルで動作させるための設定(excludeとmarkdown)の追加

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,7 @@ gauges_id: 503c5af6613f5d0f19000027
 permalink: /news/:year/:month/:day/:title/
 excerpt_separator: noifniof3nioaniof3nioafafinoafnoif
 repository: https://github.com/jekyll/jekyll
+
+# jekyllrb-ja
+exclude: ["vendor"]
+markdown: kramdown


### PR DESCRIPTION
前回の .gitignore acaa89c6d4de292bf6b9b5d85d92ffd1d3085f64 とあわせてローカルで動作させるための設定を追加しました。
