### PR TITLE
release noteに原文をコメントとして挿入/未翻訳

### DIFF
--- a/_posts/2013-05-06-jekyll-1-0-0-released.markdown
+++ b/_posts/2013-05-06-jekyll-1-0-0-released.markdown
@@ -7,17 +7,52 @@ version: 1.0.0
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.0.0 Released"
+date: "2013-05-06 02:12:52 +0200"
+author: parkr
+version: 1.0.0
+categories: [release]
+---
+-->
+
 Hey! After many months of hard work by Jekyll's contributors, we're excited
 to announce the first major release of the project in a long while. v1.0.0 is
 finally here! While the list of improvements and bug fixes is [quite lengthy][history],
 here are the highlights (thanks to [@benbalter](http://twitter.com/BenBalter) for the
 examples and for compiling this list):
 
+<!--original
+Hey! After many months of hard work by Jekyll's contributors, we're excited
+to announce the first major release of the project in a long while. v1.0.0 is
+finally here! While the list of improvements and bug fixes is [quite lengthy][history],
+here are the highlights (thanks to [@benbalter](http://twitter.com/BenBalter) for the
+examples and for compiling this list):
+-->
+
 - Support for the Gist tag for easily embedding Gists ([example](https://gist.github.com/benbalter/5555251))
 - Automatically generated post excerpts ([example](https://gist.github.com/benbalter/5555369))
 - Save and preview drafts before publishing ([example](https://gist.github.com/benbalter/5555992))
 
+<!--original
+- Support for the Gist tag for easily embedding Gists ([example](https://gist.github.com/benbalter/5555251))
+- Automatically generated post excerpts ([example](https://gist.github.com/benbalter/5555369))
+- Save and preview drafts before publishing ([example](https://gist.github.com/benbalter/5555992))
+-->
+
 Take a look at the [Upgrading][] page in the docs for more detailed information.
+
+<!--original
+Take a look at the [Upgrading][] page in the docs for more detailed information.
+-->
 
 [history]: /docs/history/#100__20130506
 [Upgrading]: /docs/upgrading/
+
+<!--original
+[history]: /docs/history/#100__20130506
+[Upgrading]: /docs/upgrading/
+-->
+

--- a/_posts/2013-05-08-jekyll-1-0-1-released.markdown
+++ b/_posts/2013-05-08-jekyll-1-0-1-released.markdown
@@ -7,7 +7,22 @@ version: 1.0.1
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.0.1 Released"
+date: "2013-05-08 23:46:11 +0200"
+author: parkr
+version: 1.0.1
+categories: [release]
+---
+-->
+
 Hot on the trails of v1.0, v1.0.1 is out! Here are the highlights:
+
+<!--original
+Hot on the trails of v1.0, v1.0.1 is out! Here are the highlights:
+-->
 
 * Add newer `language-` class name prefix to code blocks ([#1037][])
 * Commander error message now preferred over process abort with incorrect args ([#1040][])
@@ -17,7 +32,21 @@ Hot on the trails of v1.0, v1.0.1 is out! Here are the highlights:
 * Don't print deprecation warning when no arguments are specified. ([#1041][])
 * Add missing `</div>` to site template used by `new` subcommand, fixed typos in code ([#1032][])
 
+<!--original
+* Add newer `language-` class name prefix to code blocks ([#1037][])
+* Commander error message now preferred over process abort with incorrect args ([#1040][])
+* Do not force use of toc_token when using generate_toc in RDiscount ([#1048][])
+* Make Redcarpet respect the pygments configuration option ([#1053][])
+* Fix the index build with LSI ([#1045][])
+* Don't print deprecation warning when no arguments are specified. ([#1041][])
+* Add missing `</div>` to site template used by `new` subcommand, fixed typos in code ([#1032][])
+-->
+
 See the [History][] page for more information on this release.
+
+<!--original
+See the [History][] page for more information on this release.
+-->
 
 {% assign issue_numbers = "1037|1040|1048|1053|1045|1041|1032" | split: "|" %}
 {% for issue in issue_numbers %}
@@ -25,3 +54,13 @@ See the [History][] page for more information on this release.
 {% endfor %}
 
 [History]: /docs/history/#101__20130508
+
+<!--original
+{% assign issue_numbers = "1037|1040|1048|1053|1045|1041|1032" | split: "|" %}
+{% for issue in issue_numbers %}
+[#{{ issue }}]: {{ site.repository }}/issues/{{ issue }}
+{% endfor %}
+
+[History]: /docs/history/#101__20130508
+-->
+

--- a/_posts/2013-05-12-jekyll-1-0-2-released.markdown
+++ b/_posts/2013-05-12-jekyll-1-0-2-released.markdown
@@ -7,8 +7,24 @@ version: 1.0.2
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.0.2 Released"
+date: "2013-05-12 14:45:00 +0200"
+author: parkr
+version: 1.0.2
+categories: [release]
+---
+-->
+
 v1.0.2 has some key bugfixes that optionally restore some behaviour from pre-1.0
 releases, and fix some other annoying bugs:
+
+<!--original
+v1.0.2 has some key bugfixes that optionally restore some behaviour from pre-1.0
+releases, and fix some other annoying bugs:
+-->
 
 * Backwards-compatibilize relative permalinks ([#1081][])
 * Add `jekyll doctor` command to check site for any known compatibility problems ([#1081][])
@@ -18,7 +34,21 @@ releases, and fix some other annoying bugs:
 * Add a `data-lang="<lang>"` attribute to Redcarpet code blocks ([#1066][])
 * Catching that Redcarpet gem isn't installed ([#1059][])
 
+<!--original
+* Backwards-compatibilize relative permalinks ([#1081][])
+* Add `jekyll doctor` command to check site for any known compatibility problems ([#1081][])
+* Deprecate old config `server_port`, match to `port` if `port` isn't set ([#1084][])
+* Update pygments.rb and kramdon versions to 0.5.0 and 1.0.2, respectively ([#1061][], [#1067][])
+* Fix issue when post categories are numbers ([#1078][])
+* Add a `data-lang="<lang>"` attribute to Redcarpet code blocks ([#1066][])
+* Catching that Redcarpet gem isn't installed ([#1059][])
+-->
+
 See the [History][] page for more information on this release.
+
+<!--original
+See the [History][] page for more information on this release.
+-->
 
 {% assign issue_numbers = "1059|1061|1066|1067|1078|1081|1084" | split: "|" %}
 {% for issue in issue_numbers %}
@@ -26,3 +56,13 @@ See the [History][] page for more information on this release.
 {% endfor %}
 
 [History]: /docs/history/#102__20130512
+
+<!--original
+{% assign issue_numbers = "1059|1061|1066|1067|1078|1081|1084" | split: "|" %}
+{% for issue in issue_numbers %}
+[#{{ issue }}]: {{ site.repository }}/issues/{{ issue }}
+{% endfor %}
+
+[History]: /docs/history/#102__20130512
+-->
+

--- a/_posts/2013-06-07-jekyll-1-0-3-released.markdown
+++ b/_posts/2013-06-07-jekyll-1-0-3-released.markdown
@@ -7,7 +7,22 @@ version: 1.0.3
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.0.3 Released"
+date: "2013-06-07 21:02:13 +0200"
+author: parkr
+version: 1.0.3
+categories: [release]
+---
+-->
+
 v1.0.3 contains some key enhancements and bug fixes:
+
+<!--original
+v1.0.3 contains some key enhancements and bug fixes:
+-->
 
 - Fail with non-zero exit code when MaRuKu errors ([#1190][]) or Liquid errors ([#1121][])
 - Add support for private gists to `gist` tag ([#1189][])
@@ -15,7 +30,19 @@ v1.0.3 contains some key enhancements and bug fixes:
 - Fix compatibility with `exclude` and `include` with pre-1.0 Jekyll ([#1114][])
 - Fix pagination issue regarding `File.basename` and `page:num` ([#1063][])
 
+<!--original
+- Fail with non-zero exit code when MaRuKu errors ([#1190][]) or Liquid errors ([#1121][])
+- Add support for private gists to `gist` tag ([#1189][])
+- Add `--force` option to `jekyll new` ([#1115][])
+- Fix compatibility with `exclude` and `include` with pre-1.0 Jekyll ([#1114][])
+- Fix pagination issue regarding `File.basename` and `page:num` ([#1063][])
+-->
+
 See the [History][] page for more information on this release.
+
+<!--original
+See the [History][] page for more information on this release.
+-->
 
 {% assign issue_numbers = "1190|1121|1189|1115|1114|1063" | split: "|" %}
 {% for issue in issue_numbers %}
@@ -23,3 +50,13 @@ See the [History][] page for more information on this release.
 {% endfor %}
 
 [History]: /docs/history/#103__20130607
+
+<!--original
+{% assign issue_numbers = "1190|1121|1189|1115|1114|1063" | split: "|" %}
+{% for issue in issue_numbers %}
+[#{{ issue }}]: {{ site.repository }}/issues/{{ issue }}
+{% endfor %}
+
+[History]: /docs/history/#103__20130607
+-->
+

--- a/_posts/2013-07-14-jekyll-1-1-0-released.markdown
+++ b/_posts/2013-07-14-jekyll-1-1-0-released.markdown
@@ -7,8 +7,24 @@ version: 1.1.0
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.1.0 Released"
+date: "2013-07-14 19:38:02 +0200"
+author: parkr
+version: 1.1.0
+categories: [release]
+---
+-->
+
 After a month of hard work, the Jekyll core team is excited to announce the release of
 Jekyll v1.1.0! This latest release of Jekyll brings some really exciting new additions:
+
+<!--original
+After a month of hard work, the Jekyll core team is excited to announce the release of
+Jekyll v1.1.0! This latest release of Jekyll brings some really exciting new additions:
+-->
 
 - Add `docs` subcommand to read Jekyll's docs when offline. ([#1046][])
 - Support passing parameters to templates in `include` tag ([#1204][])
@@ -17,7 +33,20 @@ Jekyll v1.1.0! This latest release of Jekyll brings some really exciting new add
 - Provide better error reporting when generating sites ([#1253][])
 - Latest posts first in non-LSI `related_posts` ([#1271][])
 
+<!--original
+- Add `docs` subcommand to read Jekyll's docs when offline. ([#1046][])
+- Support passing parameters to templates in `include` tag ([#1204][])
+- Add support for Liquid tags to post excerpts ([#1302][])
+- Fix pagination for subdirectories ([#1198][])
+- Provide better error reporting when generating sites ([#1253][])
+- Latest posts first in non-LSI `related_posts` ([#1271][])
+-->
+
 See the [GitHub Release][] page for more a more detailed changelog for this release.
+
+<!--original
+See the [GitHub Release][] page for more a more detailed changelog for this release.
+-->
 
 {% assign issue_numbers = "1046|1204|1302|1198|1171|1118|1098|1215|1253|1271" | split: "|" %}
 {% for issue in issue_numbers %}
@@ -25,3 +54,13 @@ See the [GitHub Release][] page for more a more detailed changelog for this rele
 {% endfor %}
 
 [GitHub Release]: {{ site.repository }}/releases/tag/v1.1.0
+
+<!--original
+{% assign issue_numbers = "1046|1204|1302|1198|1171|1118|1098|1215|1253|1271" | split: "|" %}
+{% for issue in issue_numbers %}
+[#{{ issue }}]: {{ site.repository }}/issues/{{ issue }}
+{% endfor %}
+
+[GitHub Release]: {{ site.repository }}/releases/tag/v1.1.0
+-->
+

--- a/_posts/2013-07-24-jekyll-1-1-1-released.markdown
+++ b/_posts/2013-07-24-jekyll-1-1-1-released.markdown
@@ -7,19 +7,52 @@ version: 1.1.1
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.1.1 Released"
+date: "2013-07-24 22:24:14 +0200"
+author: parkr
+version: 1.1.1
+categories: [release]
+---
+-->
+
 
 Coming just 10 days after the release of v1.1.0, v1.1.1 is out with a patch for the nasty
 excerpt inception bug ([#1339][]) and non-zero exit codes for invalid commands
 ([#1338][]).
 
+<!--original
+
+Coming just 10 days after the release of v1.1.0, v1.1.1 is out with a patch for the nasty
+excerpt inception bug ([#1339][]) and non-zero exit codes for invalid commands
+([#1338][]).
+-->
+
 To all those affected by the [strange excerpt bug in v1.1.0][#1321], I'm sorry. I think we
 have it all patched up and it should be deployed to [GitHub Pages][gh_pages] in the next
 couple weeks. Thank you for your patience!
 
+<!--original
+To all those affected by the [strange excerpt bug in v1.1.0][#1321], I'm sorry. I think we
+have it all patched up and it should be deployed to [GitHub Pages][gh_pages] in the next
+couple weeks. Thank you for your patience!
+-->
+
 If you're checking out v1.1.x for the first time, definitely check out [what shipped with
 v1.1.0!][v1_1_0]
 
+<!--original
+If you're checking out v1.1.x for the first time, definitely check out [what shipped with
+v1.1.0!][v1_1_0]
+-->
+
 See the [GitHub Release][] page for more a more detailed changelog for this release.
+
+<!--original
+See the [GitHub Release][] page for more a more detailed changelog for this release.
+-->
 
 {% assign issue_numbers = "1339|1338|1321" | split: "|" %}
 {% for issue in issue_numbers %}
@@ -29,3 +62,14 @@ See the [GitHub Release][] page for more a more detailed changelog for this rele
 [GitHub Release]: {{ site.repository }}/releases/tag/v1.1.1
 [gh_pages]: http://pages.github.com
 [v1_1_0]: {{ site.repository }}/releases/tag/v1.1.0
+
+<!--original
+{% assign issue_numbers = "1339|1338|1321" | split: "|" %}
+{% for issue in issue_numbers %}
+[#{{ issue }}]: {{ site.repository }}/issues/{{ issue }}
+{% endfor %}
+
+[GitHub Release]: {{ site.repository }}/releases/tag/v1.1.1
+[gh_pages]: http://pages.github.com
+[v1_1_0]: {{ site.repository }}/releases/tag/v1.1.0
+-->

--- a/_posts/2013-07-25-jekyll-1-0-4-released.markdown
+++ b/_posts/2013-07-25-jekyll-1-0-4-released.markdown
@@ -7,14 +7,47 @@ version: 1.0.4
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.0.4 Released"
+date: "2013-07-25 09:08:38 +0200"
+author: mattr-
+version: 1.0.4
+categories: [release]
+---
+-->
+
 Version 1.0.4 fixes a minor, but nonetheless important security vulnerability affecting several third-party Jekyll plugins. If your Jekyll site does not use plugins, you may, but are not required to upgrade at this time.
+
+<!--original
+Version 1.0.4 fixes a minor, but nonetheless important security vulnerability affecting several third-party Jekyll plugins. If your Jekyll site does not use plugins, you may, but are not required to upgrade at this time.
+-->
 
 Community and custom plugins extending the `Liquid::Drop` class may inadvertently disclose some system information such as directory structure or software configuration to users with access to the Liquid templating system. 
 
+<!--original
+Community and custom plugins extending the `Liquid::Drop` class may inadvertently disclose some system information such as directory structure or software configuration to users with access to the Liquid templating system. 
+-->
+
 We recommend you upgrade to Jekyll v1.0.4 immediately if you use `Liquid::Drop` plugins on your Jekyll site.
+
+<!--original
+We recommend you upgrade to Jekyll v1.0.4 immediately if you use `Liquid::Drop` plugins on your Jekyll site.
+-->
 
 Many thanks for [Ben Balter](http://github.com/benbalter) for alerting us to the problem
 and [submitting a patch][1349] so quickly.
 
+<!--original
+Many thanks for [Ben Balter](http://github.com/benbalter) for alerting us to the problem
+and [submitting a patch][1349] so quickly.
+-->
+
 [230]: https://github.com/Shopify/liquid/pull/230
 [1349]: {{ site.repository }}/issues/1349
+
+<!--original
+[230]: https://github.com/Shopify/liquid/pull/230
+[1349]: {{ site.repository }}/issues/1349
+-->

--- a/_posts/2013-07-25-jekyll-1-1-2-released.markdown
+++ b/_posts/2013-07-25-jekyll-1-1-2-released.markdown
@@ -7,14 +7,47 @@ version: 1.1.2
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.1.2 Released"
+date: "2013-07-25 09:08:38 +0200"
+author: parkr
+version: 1.1.2
+categories: [release]
+---
+-->
+
 Version 1.1.2 fixes a minor, but nonetheless important security vulnerability affecting several third-party Jekyll plugins. If your Jekyll site does not use plugins, you may, but are not required to upgrade at this time.
+
+<!--original
+Version 1.1.2 fixes a minor, but nonetheless important security vulnerability affecting several third-party Jekyll plugins. If your Jekyll site does not use plugins, you may, but are not required to upgrade at this time.
+-->
 
 Community and custom plugins extending the `Liquid::Drop` class may inadvertently disclose some system information such as directory structure or software configuration to users with access to the Liquid templating system. 
 
+<!--original
+Community and custom plugins extending the `Liquid::Drop` class may inadvertently disclose some system information such as directory structure or software configuration to users with access to the Liquid templating system. 
+-->
+
 We recommend you upgrade to Jekyll v1.1.2 immediately if you use `Liquid::Drop` plugins on your Jekyll site.
+
+<!--original
+We recommend you upgrade to Jekyll v1.1.2 immediately if you use `Liquid::Drop` plugins on your Jekyll site.
+-->
 
 Many thanks for [Ben Balter](http://github.com/benbalter) for alerting us to the problem
 and [submitting a patch][1349] so quickly.
 
+<!--original
+Many thanks for [Ben Balter](http://github.com/benbalter) for alerting us to the problem
+and [submitting a patch][1349] so quickly.
+-->
+
 [230]: https://github.com/Shopify/liquid/pull/230
 [1349]: {{ site.repository }}/issues/1349
+
+<!--original
+[230]: https://github.com/Shopify/liquid/pull/230
+[1349]: {{ site.repository }}/issues/1349
+-->

--- a/_posts/2013-09-06-jekyll-1-2-0-released.markdown
+++ b/_posts/2013-09-06-jekyll-1-2-0-released.markdown
@@ -7,11 +7,32 @@ version: 1.2.0
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: "Jekyll 1.2.0 Released"
+date: "2013-09-06 22:02:41 -0400"
+author: parkr
+version: 1.2.0
+categories: [release]
+---
+-->
+
 After nearly a month and a half of hard work, the Jekyll team is happy to
 announce the release of v1.2.0. It's chock full of bug fixes and some
 enhancements that we think you'll love.
 
+<!--original
+After nearly a month and a half of hard work, the Jekyll team is happy to
+announce the release of v1.2.0. It's chock full of bug fixes and some
+enhancements that we think you'll love.
+-->
+
 Here are a few things we think you'll want to know about this release:
+
+<!--original
+Here are a few things we think you'll want to know about this release:
+-->
 
 * Run `jekyll serve --detach` to boot up a WEBrick server in the background. **Note:** you'll need to run `kill [server_pid]` to shut the server down.
 * You can now **disable automatically-generated excerpts** if you set `excerpt_separator` to `""`.
@@ -20,4 +41,17 @@ Here are a few things we think you'll want to know about this release:
 * Permalinks with special characters should now generate without errors.
 * Expose the current Jekyll version as the `jekyll.version` Liquid variable.
 
+<!--original
+* Run `jekyll serve --detach` to boot up a WEBrick server in the background. **Note:** you'll need to run `kill [server_pid]` to shut the server down.
+* You can now **disable automatically-generated excerpts** if you set `excerpt_separator` to `""`.
+* If you're moving around pages and post, you can now check for **URL conflicts** by running `jekyll doctor`.
+* If you're a fan of the drafts feature, you'll be happy to know we've added `-D`, a shortened version of `--drafts`.
+* Permalinks with special characters should now generate without errors.
+* Expose the current Jekyll version as the `jekyll.version` Liquid variable.
+-->
+
 For a full run-down, visit our [change log](/docs/history/)!
+
+<!--original
+For a full run-down, visit our [change log](/docs/history/)!
+-->

--- a/_posts/2013-09-14-jekyll-1-2-1-released.markdown
+++ b/_posts/2013-09-14-jekyll-1-2-1-released.markdown
@@ -7,13 +7,41 @@ version: 1.2.1
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.2.1 Released'
+date: 2013-09-14 20:46:50 -0400
+author: parkr
+version: 1.2.1
+categories: [release]
+---
+-->
+
 Quick turnover, anyone? A [recent incompatibility with Liquid
 v2.5.2](https://github.com/jekyll/jekyll/pull/1525) produced a nasty bug in
 which `include` tags were not rendered properly within `if` blocks. 
+
+<!--original
+Quick turnover, anyone? A [recent incompatibility with Liquid
+v2.5.2](https://github.com/jekyll/jekyll/pull/1525) produced a nasty bug in
+which `include` tags were not rendered properly within `if` blocks. 
+-->
 
 This release also includes a better handling of detached servers (prints pid and
 the command for killing the process). **Note**: the `--detach` flag and
 `--watch` flags are presently incompatible in 1.2.x. Fix for that coming soon!
 
+<!--original
+This release also includes a better handling of detached servers (prints pid and
+the command for killing the process). **Note**: the `--detach` flag and
+`--watch` flags are presently incompatible in 1.2.x. Fix for that coming soon!
+-->
+
 For a full list of the fixes in this release, check out [the change
 log](/docs/history/)!
+
+<!--original
+For a full list of the fixes in this release, check out [the change
+log](/docs/history/)!
+-->

--- a/_posts/2013-10-28-jekyll-1-3-0-rc1-released.markdown
+++ b/_posts/2013-10-28-jekyll-1-3-0-rc1-released.markdown
@@ -7,13 +7,37 @@ version: 1.3.0.rc1
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.3.0.rc1 Released'
+date: 2013-10-28 20:14:39 -0500
+author: mattr-
+version: 1.3.0.rc1
+categories: [release]
+---
+-->
+
 Jekyll 1.3.0 is going to be a big release! In order to make sure we
 didn't screw anything up too badly, we're making a release candidate
 available for any early adopters who want to give the latest and
 greatest code a spin without having to clone a repository from git.
 
+<!--original
+Jekyll 1.3.0 is going to be a big release! In order to make sure we
+didn't screw anything up too badly, we're making a release candidate
+available for any early adopters who want to give the latest and
+greatest code a spin without having to clone a repository from git.
+-->
+
+Please take this prerelease for a spin and [let us
+know](https://github.com/jekyll/jekyll/issues/new) if you run into any
+issues!
+
+<!--original
 Please take this prerelease for a spin and [let us
 know](https://github.com/jekyll/jekyll/issues/new) if you run into any
 issues!
 
 
+-->

--- a/_posts/2013-11-04-jekyll-1-3-0-released.markdown
+++ b/_posts/2013-11-04-jekyll-1-3-0-released.markdown
@@ -7,37 +7,105 @@ version: 1.3.0
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.3.0 Released'
+date: 2013-11-04 21:46:02 -0600
+author: mattr-
+version: 1.3.0
+categories: [release]
+---
+-->
+
 It's been about six weeks since v1.2.0 and the Jekyll team is happy to
 announce the arrival of v1.3.0. This is a **huge** release full of all
 sorts of new features, bug fixes, and other things that you're sure to
 love.
 
+<!--original
+It's been about six weeks since v1.2.0 and the Jekyll team is happy to
+announce the arrival of v1.3.0. This is a **huge** release full of all
+sorts of new features, bug fixes, and other things that you're sure to
+love.
+-->
+
 Here are a few things we think you'll want to know about this release:
+
+<!--original
+Here are a few things we think you'll want to know about this release:
+-->
 
 * You can add [arbitrary data][] to the site by adding YAML files under a
   site's `_data` directory. This will allow you to avoid
   repetition in your templates and to set site specific options without
   changing `_config.yml`.
 
+<!--original
+* You can add [arbitrary data][] to the site by adding YAML files under a
+  site's `_data` directory. This will allow you to avoid
+  repetition in your templates and to set site specific options without
+  changing `_config.yml`.
+-->
+
 * You can now run `jekyll serve --detach` to boot up a WEBrick server in the
   background. **Note:** you'll need to run `kill [server_pid]` to shut
   the server down. When ran, you'll get a process id that you can use in
   place of `[server_pid]`
 
+<!--original
+* You can now run `jekyll serve --detach` to boot up a WEBrick server in the
+  background. **Note:** you'll need to run `kill [server_pid]` to shut
+  the server down. When ran, you'll get a process id that you can use in
+  place of `[server_pid]`
+-->
+
 * You can now **disable automatically-generated excerpts** if you set
   `excerpt_separator` to `""`.
+
+<!--original
+* You can now **disable automatically-generated excerpts** if you set
+  `excerpt_separator` to `""`.
+-->
 
 * If you're moving pages and posts, you can now check for **URL
   conflicts** by running `jekyll doctor`.
 
+<!--original
+* If you're moving pages and posts, you can now check for **URL
+  conflicts** by running `jekyll doctor`.
+-->
+
 * If you're a fan of the drafts feature, you'll be happy to know we've
   added `-D`, a shortened version of `--drafts`.
 
+<!--original
+* If you're a fan of the drafts feature, you'll be happy to know we've
+  added `-D`, a shortened version of `--drafts`.
+-->
+
 * Permalinks with special characters should now generate without errors.
+
+<!--original
+* Permalinks with special characters should now generate without errors.
+-->
 
 * Expose the current Jekyll version as the `jekyll.version` Liquid
   variable.
 
+<!--original
+* Expose the current Jekyll version as the `jekyll.version` Liquid
+  variable.
+-->
+
 For a full run-down, visit our [change log](/docs/history/)!
 
+<!--original
+For a full run-down, visit our [change log](/docs/history/)!
+-->
+
 [arbitrary data]: /docs/datafiles/
+
+<!--original
+[arbitrary data]: /docs/datafiles/
+-->

--- a/_posts/2013-11-26-jekyll-1-3-1-released.markdown
+++ b/_posts/2013-11-26-jekyll-1-3-1-released.markdown
@@ -7,15 +7,45 @@ version: 1.3.1
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.3.1 Released'
+date: 2013-11-26 19:52:20 -0600
+author: mattr-
+version: 1.3.1
+categories: [release]
+---
+-->
+
 Just in time for the US holiday Thanksgiving, we're releasing version
 1.3.1 of Jekyll to address some of the issues seen since the
 release of 1.3.0.
+
+<!--original
+Just in time for the US holiday Thanksgiving, we're releasing version
+1.3.1 of Jekyll to address some of the issues seen since the
+release of 1.3.0.
+-->
 
 In addition to a couple of other smaller bug fixes, the biggest thing
 we've fixed is an issue with the `--watch` option with Ruby 1.8.7. For a
 full run-down, visit our [change log](/docs/history/)!
 
+<!--original
+In addition to a couple of other smaller bug fixes, the biggest thing
+we've fixed is an issue with the `--watch` option with Ruby 1.8.7. For a
+full run-down, visit our [change log](/docs/history/)!
+-->
+
 Thanks to all the people who have contributed to this release! They are
 (in alphabetical order): Abhi Yerra, Anatol Broder, Andreas Möller, Greg
 Karékinian, Sam Rayner, Santeri Paavolainen, Shigeya Suzuki, Yihang Ho,
 albertogg, andrewhavens, maul.esel, and thomasdao
+
+<!--original
+Thanks to all the people who have contributed to this release! They are
+(in alphabetical order): Abhi Yerra, Anatol Broder, Andreas Möller, Greg
+Karékinian, Sam Rayner, Santeri Paavolainen, Shigeya Suzuki, Yihang Ho,
+albertogg, andrewhavens, maul.esel, and thomasdao
+-->

--- a/_posts/2013-12-07-jekyll-1-4-0-released.markdown
+++ b/_posts/2013-12-07-jekyll-1-4-0-released.markdown
@@ -7,24 +7,71 @@ version: 1.4.0
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.4.0 Released'
+date: 2013-12-07 13:55:28 -0600
+author: mattr-
+version: 1.4.0
+categories: [release]
+---
+-->
+
 About a month after the release of Jekyll v1.3.0, we are releasing
 Jekyll v1.4.0. This release will be the last non-patch release to support Ruby
 1.8.7 and our next release will be Jekyll 2.0.0.
 
+<!--original
+About a month after the release of Jekyll v1.3.0, we are releasing
+Jekyll v1.4.0. This release will be the last non-patch release to support Ruby
+1.8.7 and our next release will be Jekyll 2.0.0.
+-->
+
 Here are a few things we think you'll want to know about this release:
+
+<!--original
+Here are a few things we think you'll want to know about this release:
+-->
 
 * TOML is now a supported markup language for config files.
 
+<!--original
+* TOML is now a supported markup language for config files.
+-->
+
 * Maruku has been updated to 0.7.0 which provides some new features and
   a ton of bugfixes over the previous 0.6.x releases.
+
+<!--original
+* Maruku has been updated to 0.7.0 which provides some new features and
+  a ton of bugfixes over the previous 0.6.x releases.
+-->
 
 * Non-`gem` Plugins are now sorted alphabetically by filename before they're
   processed, which can provide a rudimentary way to establish a load order for
   plugins.
 
+<!--original
+* Non-`gem` Plugins are now sorted alphabetically by filename before they're
+  processed, which can provide a rudimentary way to establish a load order for
+  plugins.
+-->
+
 For a full run-down, visit our [change log](/docs/history/)!
+
+<!--original
+For a full run-down, visit our [change log](/docs/history/)!
+-->
 
 As always, Jekyll wouldn't be possible without the contributions from
 others in the Jekyll community. We'd like to thank the following people
 for contributing to this release: Anatol Broder, David Sawyer, Greg
 Karékinian, Jordon Bedwell, Matthew Iversen, Persa Zula, and Yi Zeng.
+
+<!--original
+As always, Jekyll wouldn't be possible without the contributions from
+others in the Jekyll community. We'd like to thank the following people
+for contributing to this release: Anatol Broder, David Sawyer, Greg
+Karékinian, Jordon Bedwell, Matthew Iversen, Persa Zula, and Yi Zeng.
+-->

--- a/_posts/2013-12-09-jekyll-1-4-1-released.markdown
+++ b/_posts/2013-12-09-jekyll-1-4-1-released.markdown
@@ -7,14 +7,41 @@ version: 1.4.1
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.4.1 Released'
+date: 2013-12-09 20:44:13 -0600
+author: mattr-
+version: 1.4.1
+categories: [release]
+---
+-->
+
 Another quick turnover, anyone? A [critical
 bug]({{ site.repository }}/issues/1794) in the reading of
 posts snuck itself into the 1.4.0 release.
 
+<!--original
+Another quick turnover, anyone? A [critical
+bug]({{ site.repository }}/issues/1794) in the reading of
+posts snuck itself into the 1.4.0 release.
+-->
+
 To address this issue, we're releasing v1.4.1 of Jekyll so that you can
 keep on writing without any problems.
+
+<!--original
+To address this issue, we're releasing v1.4.1 of Jekyll so that you can
+keep on writing without any problems.
+-->
 
 As always, you can find the full list of fixes in this release in the
 [change log](/docs/history/)!
 
+<!--original
+As always, you can find the full list of fixes in this release in the
+[change log](/docs/history/)!
 
+
+-->

--- a/_posts/2013-12-16-jekyll-1-4-2-released.markdown
+++ b/_posts/2013-12-16-jekyll-1-4-2-released.markdown
@@ -7,12 +7,39 @@ version: 1.4.2
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.4.2 Released'
+date: 2013-12-16 19:48:13 -0500
+author: parkr
+version: 1.4.2
+categories: [release]
+---
+-->
+
 This release fixes [a regression][] where Maruku fenced code blocks were turned
 off, instead of the previous default to on. We've added a new default
 configuration to our `maruku` config key: `fenced_code_blocks` and set it to
 default to `true`.
 
+<!--original
+This release fixes [a regression][] where Maruku fenced code blocks were turned
+off, instead of the previous default to on. We've added a new default
+configuration to our `maruku` config key: `fenced_code_blocks` and set it to
+default to `true`.
+-->
+
 If you do not wish to use Maruku fenced code blocks, you may turn this option
 off in your site's configuration file.
 
+<!--original
+If you do not wish to use Maruku fenced code blocks, you may turn this option
+off in your site's configuration file.
+-->
+
 [a regression]: https://github.com/jekyll/jekyll/pull/1830
+
+<!--original
+[a regression]: https://github.com/jekyll/jekyll/pull/1830
+-->

--- a/_posts/2014-01-13-jekyll-1-4-3-released.markdown
+++ b/_posts/2014-01-13-jekyll-1-4-3-released.markdown
@@ -7,20 +7,57 @@ version: 1.4.3
 categories: [release]
 ---
 
+<!--original
+---
+layout: news_item
+title: 'Jekyll 1.4.3 Released'
+date: 2014-01-13 17:43:32 -0800
+author: benbalter
+version: 1.4.3
+categories: [release]
+---
+-->
+
 Jekyll 1.4.3 contains two **critical** security fixes. If you run Jekyll locally
 and do not run Jekyll in "safe" mode (e.g. you do not build Jekyll sites on behalf
 of others), you are not affected and are not required to update at this time.
 ([See pull request.]({{ site.repository }}/pull/1944))
+
+<!--original
+Jekyll 1.4.3 contains two **critical** security fixes. If you run Jekyll locally
+and do not run Jekyll in "safe" mode (e.g. you do not build Jekyll sites on behalf
+of others), you are not affected and are not required to update at this time.
+([See pull request.]({{ site.repository }}/pull/1944))
+-->
 
 Versions of Jekyll prior to 1.4.3 and greater than 1.2.0 may allow malicious
 users to expose the content of files outside the source directory in the
 generated output via improper symlink sanitization, potentially resulting in an
 inadvertent information disclosure.
 
+<!--original
+Versions of Jekyll prior to 1.4.3 and greater than 1.2.0 may allow malicious
+users to expose the content of files outside the source directory in the
+generated output via improper symlink sanitization, potentially resulting in an
+inadvertent information disclosure.
+-->
+
 Versions of Jekyll prior to 1.4.3 may also allow malicious users to write
 arbitrary `.html` files outside of the destination folder via relative path
 traversal, potentially overwriting otherwise-trusted content with arbitrary HTML
 or Javascript depending on your server's configuration.
 
+<!--original
+Versions of Jekyll prior to 1.4.3 may also allow malicious users to write
+arbitrary `.html` files outside of the destination folder via relative path
+traversal, potentially overwriting otherwise-trusted content with arbitrary HTML
+or Javascript depending on your server's configuration.
+-->
+
 *Maintainer's note: Many thanks to @gregose and @charliesome for discovering
 these vulnerabilities, and to @BenBalter and @alindeman for writing the patch.*
+
+<!--original
+*Maintainer's note: Many thanks to @gregose and @charliesome for discovering
+these vulnerabilities, and to @BenBalter and @alindeman for writing the patch.*
+-->


### PR DESCRIPTION
#27 の議論でrelease noteは取り敢えず翻訳しないとなりましたが、diffで差分がでないよう原文をコメントアウトで挿入しました。
