### PR TITLE
refコマンドの追加 + α

### DIFF
--- a/jekyllja.thor
+++ b/jekyllja.thor
@@ -127,14 +127,14 @@ class Jekyllja < Thor
     ref_shas =
       case ref
       when 'all'
-        Octokit.refs(options[:repo]).map do |res|
+        get_ref(options[:repo]).map do |res|
           {ref:res[:ref], sha:res[:object][:sha]}
         end
       when /^v\d/
-        res = Octokit.ref(options[:repo], "tags/#{ref}")
+        res = get_ref(options[:repo], "tags/#{ref}")
         [{ref:"ref/tags/#{ref}", sha:res[:object][:sha]}]
       else
-        res = Octokit.ref(options[:repo], "heads/#{ref}")
+        res = get_ref(options[:repo], "heads/#{ref}")
         [{ref:"ref/heads/#{ref}", sha:res[:object][:sha]}]
       end
     if options[:stdout]
@@ -204,6 +204,18 @@ class Jekyllja < Thor
     rescue ::Octokit::Unauthorized
       puts "Bad Credentials"
       exit(1)
+    end
+
+    def get_ref(repo, ref=nil)
+      if (user=options[:username]) && (pwd=options[:password])
+        github_auth(user, pwd)
+      end
+      case ref
+      when :all, nil
+        Octokit.refs(repo)
+      else
+        Octokit.ref(repo, ref)
+      end
     end
 
     def build_ref_message(ref)


### PR DESCRIPTION
jekyllja.thorに`ref`コマンドというのを追加してみました。

`ref`はブランチ名（またはタグ名）を渡すとそのリビジョン番号を返します（省略でmaster）。

``` bash
% thor jekyllja:ref master
ref/heads/master => df33ff74627b3e3df5ecd00babc28d8428630448

% thor jekyllja:ref v2.0.0
ref/tags/v2.0.0 => d4bc707ba0f206080afc909f1f8a596e3477f6ec

% thor jekyllja:ref
ref/heads/master => df33ff74627b3e3df5ecd00babc28d8428630448
```

`all`を渡すと、全リファレンスのそれを返します。

``` bash
% thor jekyllja:ref all
refs/heads/0.12.1-release             => 6cc53417798aaccce8dea6ea954cf54707098a79
refs/heads/1.0-branch                 => 8a9f8dce49e3c6377f3cd361a7e81759eb994183
refs/heads/1.2_branch                 => 6c5f7c587ea9d3727959b3e8402f3aa9c1d811c1
refs/heads/book                       => cf71631c343894456dea827b2ad3abf487c440ec
refs/heads/collections-take-2         => 82d066761ae29e5fe8244223d048b6de3035fabc
refs/heads/decouple-sass-coffeescript => 0f6d83381b0b682ab10a27c92ff84bc67024befc
refs/heads/docs-4-ci                  => 30728b2fd2e9a3a9f6964bb5500b3e9462d0f30f
. . .
```
### diff コマンドの変更

この結果を`diff`コマンドの出力にも挿入するようにしました。

``` bash
% thor jekyllja:diff docs/quickstart.md
Base revision: df33ff74627b3e3df5ecd00babc28d8428630448[ref/heads/master]
--- /var/folders/sk/9h0z77c10g16n_vc0khd_chr0000gn/T/--local-quickstart.md--20140617-60654-1em4rr       2014-06-17 10:59:29.000000000 +0900
+++ /var/folders/sk/9h0z77c10g16n_vc0khd_chr0000gn/T/--remote-quickstart.md--20140617-60654-1bbx1wg     2014-06-17 10:59:29.000000000 +0900
@@ -20,12 +20,6 @@
 posts, using the front-matter to control templates and layouts, and taking
 advantage of all the awesome configuration options Jekyll makes available.

-<div class="note info">
-  <h5>Redcarpet is the default Markdown engine for new sites</h5>
-  <p>In Jekyll 1.1, we switched the default markdown engine for sites
-     generated with <code>jekyll new</code> to Redcarpet</p>
-</div>
-
 If you're running into problems, ensure you have all the [requirements
 installed][Installation].

% thor jekyllja:diff docs/quickstart.md --no-print-content
Diff found on 'docs/quickstart.md' (Base revision: df33ff7[master])
```

Diffの結果をファイルに保存する場合もこの情報を共に保存します。

これを #139 に生かせないですかね？ :flushed: 
