### PR TITLE
Improve translation of 'reporting an issue' (solve for #141)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -286,7 +286,7 @@ Gotchas
   それは適用するためのあなたの仕事で、メンテナがしなければならないことを少なくするのは
   とてもよいことです。
 * あなたの GitHub issue で \[fix\], \[feature\] などのタグをつけないでください。
-  メンテナは積極的に issue を読み、彼らが問題に出くわしたらラベルをつけるでしょう。 
+  メンテナは積極的に issue を読み、彼らが問題に出くわしたらラベルをつけるでしょう。
 
 <!--original
 * If you want to bump the gem version, please put that in a separate commit.
@@ -302,8 +302,8 @@ Gotchas
   <h5>もっとよくできる方法をお知らせください！</h5>
   <p>
     Jekyll の使用とハックは楽しく単純、簡単でなければなりません。
-    なんらかの理由で苦痛を見つけた場合、 あなたの経験をGitHub の<a
-    href="{{ site.repository }}/issues/new">issue に追加</a>すると、
+    なんらかの理由で苦痛を見つけた場合、 あなたの経験をGitHub の
+    <a href="{{ site.repository }}/issues/new">issue に報告(英語)</a>すると、
     私たちはそれを改善することができます。
   </p>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,8 +124,7 @@ hazardous. Here’s what to look out for.
 -->
 
 もし、あなたが私たちがカバーしていない過程の何かにでくわしたり、
-他の人が便利だと思う tips を知っているならば、[file an
-issue]({{ site.repository }}/issues/new) をお願いします、そして
+他の人が便利だと思う tips を知っているならば、[issueに報告(英語)]({{ site.repository }}/issues/new) をお願いします、そして
 私たちはこのガイドに含む処置をします。
 
 <!--original

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,9 +17,8 @@ permalink: /docs/installation/
 -->
 
 Jekyll は数分でインストールと運用準備ができます。
-もし、それが悩みの種となっていたら、[file an
-issue]({{ site.repository }}/issues/new)に(または、プルリクエスト送信で)
-あなたが遭遇した問題を記述することで、我々がプロセスを
+もし、それが悩みの種となっていたら、[issue(英語)]({{ site.repository }}/issues/new)に
+あなたが遭遇した問題を報告することで(または、プルリクエスト送信で)、我々がプロセスを
 より簡単に変更するかもしれません。
 
 <!--original
@@ -105,8 +104,8 @@ Jekyll の gem の全ての依存関係は、上記のコマンドで自動的�
 あなたはそれらについて心配する必要はありません。
 もし Jekyll のインストールに問題が発生した場合、
 Jekyll コミュニティは、皆のための体験を向上できるので
-[トラブルシューティング](../troubleshooting/) ページか、
-[report an issue]({{ site.repository }}/issues/new) をチェックしてください。
+[トラブルシューティング](../troubleshooting/) ページをチェックするか、
+[その問題を報告(英語)]({{ site.repository }}/issues/new) してください。
 
 <!--original
 All of Jekyll’s gem dependencies are automatically installed by the above

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ permalink: /docs/troubleshooting/
 
 あなたが今までJekyllのインストールや使用した際に問題が発生した場合、
 いくつか助けになるかもしれないヒントがあります。以下にあるヒントでも解決しない場合、
-[その問題を報告]({{ site.repository }}/issues/new) してください。そうすることで
+[その問題を報告(英語)]({{ site.repository }}/issues/new) してください。そうすることで
 Jekyll コミュニティはすべての人によりよい体験を与えられます。
 
 <!--original


### PR DESCRIPTION
#141 で報告された 'file an issue' 'report an issue'などの表現を改善します。

基本的に、「issueに報告」という言い回しに統一しています。

あわせて、いきなり日本語でissueを立てないように「（英語）」という表現を追加しています。
