### PR TITLE
'_post' ディレクトリ追従のためのRakefileの更新

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -205,7 +205,7 @@ end
 #               between original repo and local.
 #   - diff:     it takes diffs target directories in original repo with commentout
 #               texts in local docs.
-# argument:
+# arguments:
 #   - revision: target revision. default: 'master'
 #   - target_dir: target directories. deault: '_docs,_posts'
 # note: You need to setup some environment variables for this task.
@@ -234,11 +234,22 @@ end
 # This task activates `dir_diff` and `diff` commands of `gh-diff`
 # with save option. Files will be saved to 'diff' directory of
 # the project root.
-desc "Save updates for doc files in original repo"
+# arguments: same as 'check_updates' task.
+desc "Save updates for files in original repo"
 task :save_updates do
-  GhDiff::CLI.start(["dir_diff", "_docs", "--save", "--ref"])
-  puts "\e[33mDiff files:\e[0m"
-  GhDiff::CLI.start(["diff", "_docs", "--commentout", "--save"])
+  base_revision = ENV['revision'] || 'master'
+  target_dirs = ENV['target_dir'] ? ENV['target_dir'].split(',').map(&:strip) : %w(_docs _posts)
+
+  flag = 0
+  target_dirs.each do |dir|
+    puts "\e[32m#{dir}\e[0m directory checking..."
+    puts
+    flag |= GhDiff::CLI.start(["dir_diff", dir, "--save", "--ref", "--revision=#{base_revision}"])
+    puts "\e[33mDiff files:\e[0m"
+    flag |= GhDiff::CLI.start(["diff", dir, "--commentout", "--save", "--revision=#{base_revision}"])
+    puts
+  end
+  flag
 end
 
 def build_issue_content(type, host, repo, revision, path)


### PR DESCRIPTION
Issue: #202 の一部を解決するための更新です。
1. `check_updates`タスクのチェック対象ディレクトリに、`_posts`を加えた。
2. `save_updates`タスクの対象ディレクトリに、`_posts`を加えた。
3. 各タスクが、`revision`と`target_dir`を引数として取れるように変更した。
4. 引数の渡し方を、`check_updates[args]`という形式から、`check_updates revision='arg'`という形式に変更した。

両タスクともデフォルトで、`revision='master'`, `target_dir='_docs,_posts`がセットされています。対象ディレクトリを`_docs`にしたいときは、`target='_docs'`としてください。

なお、Issueに上がっていた、`index.html`はチェックの対象となっていません。togglateのcommentoutはmarkdownにしか対応していないので..。htmlからコメントを抜き出すして比較するのはちょっと大変そうですねぇ。
