### PR TITLE
update extras.md fix #165

### DIFF
--- a/_docs/extras.md
+++ b/_docs/extras.md
@@ -4,7 +4,7 @@ title: Extras
 prev_section: plugins
 next_section: github-pages
 permalink: /docs/extras/
-Base revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
 ---
 
 <!--original


### PR DESCRIPTION
本家追随箇所のみ対応しました。以下の留意点があります。
- Markdownの説明については、「設定項目（Configuration）」のほうに委譲されているので、元々ここにあった説明が委譲先で使えるかもしれません（未確認）。
- 現状、本家ディレクトリ構成変更により、`rake verify_original_insertion[_docs/extras.md]`がコケます。
- で、`rake verify_original_insertion[_docs/extras.md,master]`として最新版と比較することで対応しました。
