### PR TITLE
verify_original_insertion でtogglateの代替をできるようにした

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.1.0
 script:
   - rake togglate
+#  - rake verify_original_insertion[,]
   - rake jekyll
 notifications:
   webhooks:

--- a/Rakefile
+++ b/Rakefile
@@ -125,11 +125,16 @@ task :verify_original_insertion do |x, args|
   path = args.path
   if path.nil?
     fail "A file path required: e.g. create_issue['diff/docs/index.diff']"
+  elsif path == ""
+    files = `git diff --name-only HEAD~ -- _docs`
+    path = files.split("\n")
   elsif !File.exist?(path) && File.directory?(path)
     fail "File NotFound: #{path}"
+  else
+    path = [path]
   end
 
-  paths = File.directory?(path) ? Dir["#{path}/**/*.{md,markdown}"] : [path]
+  paths = File.directory?(args.path) ? Dir["#{path}/**/*.{md,markdown}"] : path
 
   # HELP!:
   # Thread doesnt' work correctly. Sometimes Errno::ENOENT exception


### PR DESCRIPTION
マイルストーン0fbdc6944は突貫でこしらえたrake togglateでとりあえずチェックします。

verify_original_insertionタスクにtogglateと同等の機能を追加したので、
その後はこちらのタスクでTravisをまわしていこうと思います。

変更点としては、pathが"" (nilではない)の時は直前の変更ファイルを取得し、verifyするようにしました。

Travisで `verify_original_insertion[,]` のように呼び出すと
PR時にコミットされたファイルを対象にベースリビジョンで本家とdiffを取ります。
