### PR TITLE
exclude diff directory from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,4 +15,4 @@ collections:
     output: true
 
 # jekyllrb-ja
-exclude: ["vendor"]
+exclude: [vendor, diff]


### PR DESCRIPTION
[News](http://jekyllrb-ja.github.io/news/) を見たら、`diff/posts/`以下のdiffファイルが出ちゃってるのに気が付いたので、対応しました。 :sweat: 

また、quoteは不要なようなので、削除しました。
