### PR TITLE
Change base revision

### DIFF
--- a/diff/_docs/assets.diff
+++ b/diff/_docs/assets.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/assets.md
 +++ docs/assets.md
 

--- a/diff/_docs/collections.md
+++ b/diff/_docs/collections.md
@@ -4,7 +4,7 @@ title: Collections
 prev_section: variables
 next_section: datafiles
 permalink: /docs/collections/
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 ---
 
 <div class="note warning">

--- a/diff/_docs/configuration.diff
+++ b/diff/_docs/configuration.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/configuration.md
 +++ docs/configuration.md
 

--- a/diff/_docs/continuous-integration.md
+++ b/diff/_docs/continuous-integration.md
@@ -4,7 +4,7 @@ title: Continuous Integration
 prev_section: deployment-methods
 next_section: troubleshooting
 permalink: /docs/continuous-integration/
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 ---
 
 You can easily test your website build against one or more versions of Ruby.

--- a/diff/_docs/contributing.diff
+++ b/diff/_docs/contributing.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/contributing.md
 +++ docs/contributing.md
 

--- a/diff/_docs/datafiles.diff
+++ b/diff/_docs/datafiles.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/datafiles.md
 +++ docs/datafiles.md
 

--- a/diff/_docs/deployment-methods.diff
+++ b/diff/_docs/deployment-methods.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/deployment-methods.md
 +++ docs/deployment-methods.md
 

--- a/diff/_docs/extras.diff
+++ b/diff/_docs/extras.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/extras.md
 +++ docs/extras.md
 

--- a/diff/_docs/frontmatter.diff
+++ b/diff/_docs/frontmatter.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/frontmatter.md
 +++ docs/frontmatter.md
 

--- a/diff/_docs/heroku.delete
+++ b/diff/_docs/heroku.delete
@@ -1,5 +1,5 @@
 ---
 File: docs/heroku.md
 Status: file deleted
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 ---

--- a/diff/_docs/history.diff
+++ b/diff/_docs/history.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/history.md
 +++ docs/history.md
 

--- a/diff/_docs/index.diff
+++ b/diff/_docs/index.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/index.md
 +++ docs/index.md
 

--- a/diff/_docs/installation.diff
+++ b/diff/_docs/installation.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/installation.md
 +++ docs/installation.md
 

--- a/diff/_docs/migrations.diff
+++ b/diff/_docs/migrations.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/migrations.md
 +++ docs/migrations.md
 

--- a/diff/_docs/pagination.diff
+++ b/diff/_docs/pagination.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/pagination.md
 +++ docs/pagination.md
 

--- a/diff/_docs/permalinks.diff
+++ b/diff/_docs/permalinks.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/permalinks.md
 +++ docs/permalinks.md
 

--- a/diff/_docs/plugins.diff
+++ b/diff/_docs/plugins.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/plugins.md
 +++ docs/plugins.md
 

--- a/diff/_docs/posts.diff
+++ b/diff/_docs/posts.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/posts.md
 +++ docs/posts.md
 

--- a/diff/_docs/quickstart.diff
+++ b/diff/_docs/quickstart.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/quickstart.md
 +++ docs/quickstart.md
 

--- a/diff/_docs/resources.diff
+++ b/diff/_docs/resources.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/resources.md
 +++ docs/resources.md
 

--- a/diff/_docs/sites.diff
+++ b/diff/_docs/sites.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/sites.md
 +++ docs/sites.md
 

--- a/diff/_docs/structure.diff
+++ b/diff/_docs/structure.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/structure.md
 +++ docs/structure.md
 

--- a/diff/_docs/templates.diff
+++ b/diff/_docs/templates.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/templates.md
 +++ docs/templates.md
 

--- a/diff/_docs/troubleshooting.diff
+++ b/diff/_docs/troubleshooting.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/troubleshooting.md
 +++ docs/troubleshooting.md
 

--- a/diff/_docs/upgrading.diff
+++ b/diff/_docs/upgrading.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/upgrading.md
 +++ docs/upgrading.md
 

--- a/diff/_docs/usage.diff
+++ b/diff/_docs/usage.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/usage.md
 +++ docs/usage.md
 

--- a/diff/_docs/variables.diff
+++ b/diff/_docs/variables.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/variables.md
 +++ docs/variables.md
 

--- a/diff/_docs/windows.diff
+++ b/diff/_docs/windows.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[refs/heads/master]
+base_revision: e57cd00[refs/heads/master]
 --- docs/windows.md
 +++ docs/windows.md
 

--- a/diff/_posts/2013-05-06-jekyll-1-0-0-released.diff
+++ b/diff/_posts/2013-05-06-jekyll-1-0-0-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-05-06-jekyll-1-0-0-released.markdown
 +++ _posts/2013-05-06-jekyll-1-0-0-released.markdown
 

--- a/diff/_posts/2013-05-08-jekyll-1-0-1-released.diff
+++ b/diff/_posts/2013-05-08-jekyll-1-0-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-05-08-jekyll-1-0-1-released.markdown
 +++ _posts/2013-05-08-jekyll-1-0-1-released.markdown
 

--- a/diff/_posts/2013-05-12-jekyll-1-0-2-released.diff
+++ b/diff/_posts/2013-05-12-jekyll-1-0-2-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-05-12-jekyll-1-0-2-released.markdown
 +++ _posts/2013-05-12-jekyll-1-0-2-released.markdown
 

--- a/diff/_posts/2013-06-07-jekyll-1-0-3-released.diff
+++ b/diff/_posts/2013-06-07-jekyll-1-0-3-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-06-07-jekyll-1-0-3-released.markdown
 +++ _posts/2013-06-07-jekyll-1-0-3-released.markdown
 

--- a/diff/_posts/2013-07-14-jekyll-1-1-0-released.diff
+++ b/diff/_posts/2013-07-14-jekyll-1-1-0-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-07-14-jekyll-1-1-0-released.markdown
 +++ _posts/2013-07-14-jekyll-1-1-0-released.markdown
 

--- a/diff/_posts/2013-07-24-jekyll-1-1-1-released.diff
+++ b/diff/_posts/2013-07-24-jekyll-1-1-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-07-24-jekyll-1-1-1-released.markdown
 +++ _posts/2013-07-24-jekyll-1-1-1-released.markdown
 

--- a/diff/_posts/2013-07-25-jekyll-1-0-4-released.diff
+++ b/diff/_posts/2013-07-25-jekyll-1-0-4-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-07-25-jekyll-1-0-4-released.markdown
 +++ _posts/2013-07-25-jekyll-1-0-4-released.markdown
 

--- a/diff/_posts/2013-07-25-jekyll-1-1-2-released.diff
+++ b/diff/_posts/2013-07-25-jekyll-1-1-2-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-07-25-jekyll-1-1-2-released.markdown
 +++ _posts/2013-07-25-jekyll-1-1-2-released.markdown
 

--- a/diff/_posts/2013-09-06-jekyll-1-2-0-released.diff
+++ b/diff/_posts/2013-09-06-jekyll-1-2-0-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-09-06-jekyll-1-2-0-released.markdown
 +++ _posts/2013-09-06-jekyll-1-2-0-released.markdown
 

--- a/diff/_posts/2013-09-14-jekyll-1-2-1-released.diff
+++ b/diff/_posts/2013-09-14-jekyll-1-2-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-09-14-jekyll-1-2-1-released.markdown
 +++ _posts/2013-09-14-jekyll-1-2-1-released.markdown
 

--- a/diff/_posts/2013-10-28-jekyll-1-3-0-rc1-released.diff
+++ b/diff/_posts/2013-10-28-jekyll-1-3-0-rc1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-10-28-jekyll-1-3-0-rc1-released.markdown
 +++ _posts/2013-10-28-jekyll-1-3-0-rc1-released.markdown
 

--- a/diff/_posts/2013-11-04-jekyll-1-3-0-released.diff
+++ b/diff/_posts/2013-11-04-jekyll-1-3-0-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-11-04-jekyll-1-3-0-released.markdown
 +++ _posts/2013-11-04-jekyll-1-3-0-released.markdown
 

--- a/diff/_posts/2013-11-26-jekyll-1-3-1-released.diff
+++ b/diff/_posts/2013-11-26-jekyll-1-3-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-11-26-jekyll-1-3-1-released.markdown
 +++ _posts/2013-11-26-jekyll-1-3-1-released.markdown
 

--- a/diff/_posts/2013-12-07-jekyll-1-4-0-released.diff
+++ b/diff/_posts/2013-12-07-jekyll-1-4-0-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-12-07-jekyll-1-4-0-released.markdown
 +++ _posts/2013-12-07-jekyll-1-4-0-released.markdown
 

--- a/diff/_posts/2013-12-09-jekyll-1-4-1-released.diff
+++ b/diff/_posts/2013-12-09-jekyll-1-4-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-12-09-jekyll-1-4-1-released.markdown
 +++ _posts/2013-12-09-jekyll-1-4-1-released.markdown
 

--- a/diff/_posts/2013-12-16-jekyll-1-4-2-released.diff
+++ b/diff/_posts/2013-12-16-jekyll-1-4-2-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2013-12-16-jekyll-1-4-2-released.markdown
 +++ _posts/2013-12-16-jekyll-1-4-2-released.markdown
 

--- a/diff/_posts/2014-01-13-jekyll-1-4-3-released.diff
+++ b/diff/_posts/2014-01-13-jekyll-1-4-3-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-01-13-jekyll-1-4-3-released.markdown
 +++ _posts/2014-01-13-jekyll-1-4-3-released.markdown
 

--- a/diff/_posts/2014-03-24-jekyll-1-5-0-released.diff
+++ b/diff/_posts/2014-03-24-jekyll-1-5-0-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-03-24-jekyll-1-5-0-released.markdown
 +++ _posts/2014-03-24-jekyll-1-5-0-released.markdown
 

--- a/diff/_posts/2014-03-27-jekyll-1-5-1-released.diff
+++ b/diff/_posts/2014-03-27-jekyll-1-5-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-03-27-jekyll-1-5-1-released.markdown
 +++ _posts/2014-03-27-jekyll-1-5-1-released.markdown
 

--- a/diff/_posts/2014-05-06-jekyll-turns-2-0-0.diff
+++ b/diff/_posts/2014-05-06-jekyll-turns-2-0-0.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-05-06-jekyll-turns-2-0-0.markdown
 +++ _posts/2014-05-06-jekyll-turns-2-0-0.markdown
 

--- a/diff/_posts/2014-05-08-jekyll-2-0-3-released.diff
+++ b/diff/_posts/2014-05-08-jekyll-2-0-3-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-05-08-jekyll-2-0-3-released.markdown
 +++ _posts/2014-05-08-jekyll-2-0-3-released.markdown
 

--- a/diff/_posts/2014-06-04-jekyll-stickers-1-dollar-stickermule.diff
+++ b/diff/_posts/2014-06-04-jekyll-stickers-1-dollar-stickermule.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-06-04-jekyll-stickers-1-dollar-stickermule.markdown
 +++ _posts/2014-06-04-jekyll-stickers-1-dollar-stickermule.markdown
 

--- a/diff/_posts/2014-06-28-jekyll-turns-21-i-mean-2-1-0.diff
+++ b/diff/_posts/2014-06-28-jekyll-turns-21-i-mean-2-1-0.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-06-28-jekyll-turns-21-i-mean-2-1-0.markdown
 +++ _posts/2014-06-28-jekyll-turns-21-i-mean-2-1-0.markdown
 

--- a/diff/_posts/2014-07-01-jekyll-2-1-1-released.diff
+++ b/diff/_posts/2014-07-01-jekyll-2-1-1-released.diff
@@ -1,4 +1,4 @@
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 --- _posts/2014-07-01-jekyll-2-1-1-released.markdown
 +++ _posts/2014-07-01-jekyll-2-1-1-released.markdown
 

--- a/diff/_posts/2014-07-29-jekyll-2-2-0-released.delete
+++ b/diff/_posts/2014-07-29-jekyll-2-2-0-released.delete
@@ -1,5 +1,5 @@
 ---
 File: _posts/2014-07-29-jekyll-2-2-0-released.markdown
 Status: file deleted
-base_revision: 0fbdc6944041147c2d21b306751b078860b6603b[]
+base_revision: e57cd00[]
 ---


### PR DESCRIPTION
本家のディレクトリ変更のため、diff作成時(`rake save_updates`実行時)のrevisionでは`rake verify_original_insertion`がコケます(リモートのファイルが無いエラー)。

これに対処するため、diffファイルのrevisionをディレクトリ変更に係るrevisionと思われる`e57cd00`に変更しました。travis上でのverify_original_insertionの対応は @goshujin さんが対応しましたが、これで翻訳者がローカルで特定の翻訳ファイルを試すときもうまくいくと思います。
