### PR TITLE
Relax diff condition to ignore difference of space

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :togglate do
         fail "`curl`: No such file - '#{ORIGINAL_DOC_URL}/#{curl_file}'"
       end
       # system( "git diff --no-index #{local_doc} #{origin_doc}" )
-      system( "diff -u #{local_doc} #{origin_doc}" )
+      system( "diff -uw #{local_doc} #{origin_doc}" )
       case $?
       when 0
         ok_files << file


### PR DESCRIPTION
rake togglateのタスクで行末のスペースの数の異なりでCIが失敗するのを修正します。

@gosyujin @melborne 確認お願いします :pray: 
