### PR TITLE
Remove CNAME. It is not used for this project

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-jekyllrb.com


### PR DESCRIPTION
独自ドメイン運用を行わない間はこのファイルは不要だと思います。

いまはPRをマージするたびに「そのドメイン名はもう使われてるよ」という警告メールがGitHubから来て煩わしいので、これで解消されるかと。
