### PR TITLE
必要最低限の.envを追加

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+REPO=jekyll/jekyll
+REVISION=master
+DIR=site


### PR DESCRIPTION
Travisとかでgh-diff関連のタスクを実行する時に
最低限必要な環境を設定しました。

もともとバージョン管理していなかった(無視してた)ものを追加したかつ
USERNAMEとかPASSWORDのような情報は入っていないので
ローカルに取り込むときにコンフリクトするかも…
