### PR TITLE
Rakefileのtogglateタスクを本家のディレクトリ構造に合わせる（暫定）

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,8 @@ task :togglate do
       # output local document
       system( "#{togglate} commentout #{file} > #{local_doc}" )
       # output original document
-      curl_file = file.gsub(/_/, '')
+      # curl_file = file.gsub(/_/, '')
+      curl_file = file.dup
       file_exist = system( "curl -sf #{ORIGINAL_DOC_URL}/#{curl_file} > #{origin_doc}" )
       unless file_exist
         fail "`curl`: No such file - '#{ORIGINAL_DOC_URL}/#{curl_file}'"


### PR DESCRIPTION
`rake togglate` が落ちます。どうも本家のディレクトリが `_docs` であるのに `docs` を見に行っているためのようなので，とりあえず暫定対応で `gsub` しないようにしました。