### PR TITLE
ドキュメントがメンテナンスされていないことを知らせるnoteを追加

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -12,6 +12,10 @@ layout: default
           <div class="improve right hide-on-mobiles">
             <a href="https://github.com/jekyll/jekyll/edit/master/site/{{ page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
           </div>
+          <div class="note warning">
+            <h5>この日本語訳ドキュメントは長らくメンテナンスされていません</h5>
+            <p>Jekyll 2.2.0 以降を使用する際は、<a href="https://jekyllrb.com/docs/">公式ドキュメント</a>を参照してください。</p>
+          </div>
           <h1>{{ page.title }}</h1>
           {{ content }}
           {% include section_nav.html %}


### PR DESCRIPTION
## 変更内容

現在の http://jekyllrb-ja.github.io/ でもトップページには本家サイトを参照するよう促すメッセージが表示されますが、ドキュメントページにはそのようなメッセージがありません。

このプルリクエストでは、ドキュメントページ全てにドキュメントがメンテナンスされていない旨を伝えるnoteを追加しています。

## 理由

現時点で日本語圏から"Jekyll"をGoogle検索すると、 http://jekyllrb-ja.github.io/ がトップに表示されます。

![image](https://user-images.githubusercontent.com/9744580/47008635-98383780-d175-11e8-9fd7-aa3b8a6e522d.png)

このため、最新のJekyllに関する情報を求めている人が http://jekyllrb-ja.github.io/ にアクセスすることは十分考えられます。

前述の通り、トップページにしか公式のサイトではないことを知らせる手がかりがありません。そのままサイト内のドキュメントページに遷移すると、ページが公式でメンテされている内容とは異なっていることに気づくことが難しくなります。

## 背景

私自身Jekyllを最近触っていまして、インストール時にこのような流れで日本語訳ページのドキュメントを参照しました。

1. Googleで"jekyll"を検索する
2. トップに出てきた http://jekyllrb-ja.github.io/ にアクセスする
3. ドキュメントがみたいので http://jekyllrb-ja.github.io/docs/home/ にアクセスする
4. http://jekyllrb-ja.github.io/docs/quickstart/ にアクセスする

このページでは `gem install jekyll` が書かれているわけですが、 https://jekyllrb.com/docs/ では `gem install jekyll bundler` が書かれています。

私は普段あまりRubyを触らないので、bundlerを私の環境では入れていませんでした。このため日本語訳ページを参考にインストールした後に `jekyll` をターミナルで叩くとbundlerがないと怒られ、ドキュメントの内容が古いことに気づくのに時間がかかってしまいました。

私のようなケースでつまづく人がいないとも限らないなあと思ったので、プルリクエストを出してみました。