### PR TITLE
ディレクトリ構成ページの誤字修正

### DIFF
--- a/_docs/structure.md
+++ b/_docs/structure.md
@@ -192,7 +192,7 @@ permalink: /docs/structure/
       </td>
       <td>
         <p>
-          生成されたサイトがJ、ekyllが変換した際に配置される（デフォルトの）場所です。これを<code> .gitignore </code>ファイルに追加することをお勧めします。
+          生成されたサイトがJekyllが変換した際に配置される（デフォルトの）場所です。これを<code> .gitignore </code>ファイルに追加することをお勧めします。
         </p>
         <!-- <p>
           This is where the generated site will be placed (by default) once


### PR DESCRIPTION
以下の誤字を修正しました。
```
         <p>
-          生成されたサイトがJ、ekyllが変換した際に配置される（デフォルトの）場所です。これを<code> .gitignore </code>ファイルに追加することをお勧めします。
+          生成されたサイトがJekyllが変換した際に配置される（デフォルトの）場所です。これを<code> .gitignore </code>ファイルに追加することをお勧めします。
         </p>
```
fix #421